### PR TITLE
Reduce loglevel for carbon aware sdk to debug level

### DIFF
--- a/carbon-monitor/carbon_emissions/carbon_emissions.go
+++ b/carbon-monitor/carbon_emissions/carbon_emissions.go
@@ -105,7 +105,7 @@ func RefreshCarbonCache() {
 }
 
 func LoadSettings() {
-	log.Info("Loading settings")
+	log.Debug("Loading settings")
 	RefreshCarbonCache()
 
 	url := os.Getenv("CARBON_SDK_URL")
@@ -119,5 +119,5 @@ func LoadSettings() {
 		}
 		baseUrl = fmt.Sprintf("http://%s:%s", host, port)
 	}
-	log.Info(fmt.Sprintf("Using Carbon Aware SDK at %s", baseUrl))
+	log.Debug(fmt.Sprintf("Using Carbon Aware SDK at %s", baseUrl))
 }


### PR DESCRIPTION
The logging for informing us what url is used for the carbonaware sdk was set as info resulting in it always being logged

This should be a debug level log, we normally dont care, plus it interferes with the info logging of the bcgx-cli